### PR TITLE
colorize modified buffers in tabbar

### DIFF
--- a/tabbar-ruler.el
+++ b/tabbar-ruler.el
@@ -1016,36 +1016,17 @@ Call `tabbar-tab-label-function' to obtain a label for TAB."
 (defface tabbar-selected-modified
   '((t
      :inherit tabbar-selected
+     :foreground "DarkOrange3"
      :weight bold))
-  "Face used for unselected tabs."
+   "Face used for selected tabs."
   :group 'tabbar)
 
 (defface tabbar-unselected-modified
   '((t
      :inherit tabbar-unselected
+     :foreground "DarkOrange3"
      :weight bold))
-  "Face used for unselected tabs."
-  :group 'tabbar)
-
-(defface tabbar-key-binding '((t
-                               :foreground "white"))
-  "Face for unselected, highlighted tabs."
-  :group 'tabbar)
-
-
-
-(defface tabbar-selected-modified
-  '((t
-     :inherit tabbar-selected
-     :slant italic))
-  "Face used for unselected tabs."
-  :group 'tabbar)
-
-(defface tabbar-unselected-modified
-  '((t
-     :inherit tabbar-unselected
-     :slant italic))
-  "Face used for unselected tabs."
+   "Face used for unselected tabs."
   :group 'tabbar)
 
 (defface tabbar-key-binding '((t
@@ -1522,6 +1503,22 @@ remove the keymap depends on user input and KEEP-PRED:
     (setq tabbar-ruler-tabbar-off nil))
   (message "Use arrow keys to change buffers (or line movement commands).  Exit with space/return or any other key.")
   (set-temporary-overlay-map tabbar-ruler-move-keymap 'tabbar-ruler-move-pred))
+
+;; Hook save and change events to show modified buffers in tabbar
+(defun on-saving-buffer ()
+  (tabbar-set-template tabbar-current-tabset nil)
+  (tabbar-display-update))
+(defun on-modifying-buffer ()
+  (set-buffer-modified-p (buffer-modified-p))
+  (tabbar-set-template tabbar-current-tabset nil)
+  (tabbar-display-update))
+(defun after-modifying-buffer (begin end length)
+  (set-buffer-modified-p (buffer-modified-p))
+  (tabbar-set-template tabbar-current-tabset nil)
+  (tabbar-display-update))
+(add-hook 'after-save-hook 'on-saving-buffer)
+(add-hook 'first-change-hook 'on-modifying-buffer)
+(add-hook 'after-change-functions 'after-modifying-buffer)
 
 (provide 'tabbar-ruler)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Hi, 

I have tried your plug-in tabbar-ruler for Emacs recently and this perhaps the fanciest tabbar that I've used.

However, I saw that the modified buffers are not really shown perfectly. Hence, I made a minor changes that tabbar to display modified buffers name in orange colors.

If you find that my modification is helpful, please feel free to merge back into your original repository.

Best regards,
Quang Trung.
