### PR TITLE
fancy-tab-separator for current tab

### DIFF
--- a/tabbar-ruler.el
+++ b/tabbar-ruler.el
@@ -365,6 +365,14 @@
 	  (const :tag "zigzag" zigzag))
   :group 'tabbar-ruler)
 
+
+(defcustom tabbar-ruler-fancy-current-tab-separator nil
+  "Separate each tab with a fancy generated image"
+  ;; TODO: type same as "tabbar-ruler-fancy-tab-separator"
+  ;; may be inherit
+  :group 'tabbar-ruler)
+
+
 (defcustom tabbar-ruler-fancy-close-image nil
   "Use an image for the close"
   :type 'boolean
@@ -868,24 +876,25 @@ Call `tabbar-tab-label-function' to obtain a label for TAB."
                                                                                   (face-attribute 'default :foreground)
                                                                                 "gray10"))))))
           (keymap (tabbar-make-tab-keymap tab))
-	  (left-fun (intern (format "powerline-%s-left" tabbar-ruler-fancy-tab-separator)))
-	  (right-fun (intern (format "powerline-%s-right" tabbar-ruler-fancy-tab-separator)))
+          (left-fun
+           (if selected-p
+               (intern (format "powerline-%s-left" tabbar-ruler-fancy-current-tab-separator))
+               (intern (format "powerline-%s-left" tabbar-ruler-fancy-tab-separator))))
+          (right-fun
+           (if selected-p
+               (intern (format "powerline-%s-right" tabbar-ruler-fancy-current-tab-separator))
+               (intern (format "powerline-%s-right" tabbar-ruler-fancy-tab-separator))))
           (face (if selected-p
                     (if modified-p
                         'tabbar-selected-modified
                       'tabbar-selected)
                   (if modified-p
                       'tabbar-unselected-modified
-                    'tabbar-unselected)))
-	  (next-face (if not-last
-			 (if (tabbar-selected-p (car not-last) (tabbar-current-tabset))
-			     (if (buffer-modified-p (tabbar-tab-value (car not-last)))
-				 'tabbar-selected-modified
-			       'tabbar-selected)
-			   (if (buffer-modified-p (tabbar-tab-value (car not-last)))
-			       'tabbar-unselected-modified
-			     'tabbar-unselected)))))
+                    'tabbar-unselected))))
     (concat
+     (propertize "|"
+                 'display (funcall right-fun nil face 25))
+
      (propertize " " 'face face
                  'tabbar-tab tab
                  'local-map keymap
@@ -951,17 +960,7 @@ Call `tabbar-tab-label-function' to obtain a label for TAB."
       (tabbar-ruler-fancy-tab-separator ;; default
        (propertize "|"
 		   'display (funcall left-fun face nil 25)))
-      (t tabbar-separator-value))
-     (cond
-      ((or (not not-last) (not tabbar-ruler-fancy-tab-separator))
-       "")
-      (tabbar-ruler-fancy-tab-separator
-       (propertize " " 'display (funcall right-fun nil nil 2))))
-     (cond
-      ((or (not not-last) (not tabbar-ruler-fancy-tab-separator))
-       "")
-      (tabbar-ruler-fancy-tab-separator
-       (propertize "|" 'display (funcall right-fun nil next-face 25)))))))
+      (t tabbar-separator-value)))))
 
 (defsubst tabbar-line-format (tabset)
   "Return the `header-line-format' value to display TABSET."


### PR DESCRIPTION
just some hackish changes to improve the looks.

- fixed the funny tab creations side

(tab-content right-tab-ending left-tab-ending) → (left-tab-ending tab-content right-tab-ending)


added new variable 

__tabbar-ruler-fancy-current-tab-separator__


screenshot with config:

    (setq tabbar-ruler-fancy-current-tab-separator 'wave)
    (setq tabbar-ruler-fancy-tab-separator 'alternate)

![screenshot62](https://cloud.githubusercontent.com/assets/1684754/12316097/d3028602-baaa-11e5-9694-ff93b438b972.png)

![screenshot61](https://cloud.githubusercontent.com/assets/1684754/12316086/b844084a-baaa-11e5-8b82-753231a3c331.png)

