### PR TITLE
Fix void-variable ret error in lexical binding

### DIFF
--- a/tabbar-ruler.el
+++ b/tabbar-ruler.el
@@ -820,7 +820,7 @@ be \"Could not gzip the file!\"."
                            (format "%02X" (* val 255)))
                          (color-name-to-rgb color) ""))))
      (t (setq ret "None")))
-    (symbol-value 'ret)))
+    ret))
 
 (defcustom tabbar-ruler-swap-faces nil
   "Swap the selected / unselected tab colors."


### PR DESCRIPTION
tabbar-ruler.el (tabbar-hex-color): Return 'ret' directly instead of using 'symbol-value'. This fixes the "void-variable ret" error triggered when lexical-binding is enabled.